### PR TITLE
Add OAuth auth helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,17 @@ Built with the power of **Multi-Model AI** collaboration 🤝
 - [Gemini 2.5 Pro & 2.0 Flash](https://ai.google.dev/) - Extended thinking & fast analysis
 - [OpenAI O3](https://openai.com/) - Strong reasoning & general intelligence
 
+### Authentication
+
+Use the `auth_cli.py` helper to store credentials for providers. Run:
+
+```bash
+python scripts/auth_cli.py login
+```
+
+Then select the provider and follow the prompts. Credentials are saved to
+`~/.local/share/zen-mcp-server/auth.json`.
+
 ### Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=BeehiveInnovations/zen-mcp-server&type=Date)](https://www.star-history.com/#BeehiveInnovations/zen-mcp-server&Date)

--- a/auth/__init__.py
+++ b/auth/__init__.py
@@ -1,0 +1,33 @@
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+APP_NAME = "zen-mcp-server"
+DATA_DIR = Path.home() / ".local" / "share" / APP_NAME
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+AUTH_FILE = DATA_DIR / "auth.json"
+
+
+def _load_all() -> dict[str, Any]:
+    if not AUTH_FILE.exists():
+        return {}
+    try:
+        return json.loads(AUTH_FILE.read_text())
+    except Exception:
+        return {}
+
+
+def all() -> dict[str, Any]:
+    return _load_all()
+
+
+def get(key: str) -> Optional[dict[str, Any]]:
+    return _load_all().get(key)
+
+
+def set(key: str, info: dict[str, Any]) -> None:
+    data = _load_all()
+    data[key] = info
+    AUTH_FILE.write_text(json.dumps(data, indent=2))
+    os.chmod(AUTH_FILE, 0o600)

--- a/auth/anthropic.py
+++ b/auth/anthropic.py
@@ -1,0 +1,105 @@
+import base64
+import hashlib
+import os
+import time
+from typing import Optional
+
+import requests
+
+from . import get, set
+
+CLIENT_ID = os.getenv("ANTHROPIC_CLIENT_ID", "")
+AUTHORIZE_URL = "https://claude.ai/oauth/authorize"
+TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
+REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
+SCOPE = "org:create_api_key user:profile user:inference"
+
+
+def _generate_pkce() -> dict[str, str]:
+    verifier = base64.urlsafe_b64encode(os.urandom(32)).rstrip(b"=").decode()
+    challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+    return {"verifier": verifier, "challenge": challenge}
+
+
+def generate_oauth_url() -> dict[str, str]:
+    pkce = _generate_pkce()
+    params = {
+        "code": "true",
+        "client_id": CLIENT_ID,
+        "response_type": "code",
+        "redirect_uri": REDIRECT_URI,
+        "scope": SCOPE,
+        "code_challenge": pkce["challenge"],
+        "code_challenge_method": "S256",
+        "state": pkce["verifier"],
+    }
+    query = "&".join(f"{k}={v}" for k, v in params.items())
+    url = f"{AUTHORIZE_URL}?{query}"
+    return {"url": url, "verifier": pkce["verifier"]}
+
+
+def exchange_code(code: str, state: str, verifier: str) -> Optional[str]:
+    response = requests.post(
+        TOKEN_URL,
+        json={
+            "code": code,
+            "state": state,
+            "grant_type": "authorization_code",
+            "client_id": CLIENT_ID,
+            "redirect_uri": REDIRECT_URI,
+            "code_verifier": verifier,
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    if not response.ok:
+        return None
+    data = response.json()
+    set(
+        "anthropic",
+        {
+            "type": "oauth",
+            "refresh": data.get("refresh_token"),
+            "access": data.get("access_token"),
+            "expires": int(time.time() * 1000 + data.get("expires_in", 0) * 1000),
+        },
+    )
+    return data.get("access_token")
+
+
+def _refresh() -> Optional[str]:
+    info = get("anthropic")
+    if not info or info.get("type") != "oauth":
+        return None
+    response = requests.post(
+        TOKEN_URL,
+        json={
+            "grant_type": "refresh_token",
+            "refresh_token": info.get("refresh"),
+            "client_id": CLIENT_ID,
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    if not response.ok:
+        return None
+    data = response.json()
+    set(
+        "anthropic",
+        {
+            "type": "oauth",
+            "refresh": data.get("refresh_token"),
+            "access": data.get("access_token"),
+            "expires": int(time.time() * 1000 + data.get("expires_in", 0) * 1000),
+        },
+    )
+    return data.get("access_token")
+
+
+def get_access_token() -> Optional[str]:
+    info = get("anthropic")
+    if not info or info.get("type") != "oauth":
+        return None
+    access = info.get("access")
+    expires = info.get("expires", 0)
+    if access and expires > int(time.time() * 1000):
+        return access
+    return _refresh()

--- a/auth/github_copilot.py
+++ b/auth/github_copilot.py
@@ -1,0 +1,92 @@
+import os
+import time
+from typing import Optional
+
+import requests
+
+from . import get, set
+
+CLIENT_ID = os.getenv("GITHUB_COPILOT_CLIENT_ID", "d1b5d6e646903b9ee0ac")
+DEVICE_CODE_URL = "https://github.com/login/device/code"
+ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
+COPILOT_API_KEY_URL = "https://api.github.com/copilot_internal/v2/token"
+
+HEADERS = {
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+    "User-Agent": "GitHubCopilotChat/0.26.7",
+}
+
+
+def start_device_flow() -> dict[str, any]:
+    resp = requests.post(
+        DEVICE_CODE_URL,
+        headers=HEADERS,
+        json={"client_id": CLIENT_ID, "scope": "read:user"},
+    )
+    data = resp.json()
+    return {
+        "device": data.get("device_code"),
+        "user": data.get("user_code"),
+        "verification": data.get("verification_uri"),
+        "interval": data.get("interval", 5),
+        "expiry": data.get("expires_in"),
+    }
+
+
+def poll_token(device_code: str) -> str:
+    resp = requests.post(
+        ACCESS_TOKEN_URL,
+        headers=HEADERS,
+        json={
+            "client_id": CLIENT_ID,
+            "device_code": device_code,
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+        },
+    )
+    if not resp.ok:
+        return "failed"
+    data = resp.json()
+    if "access_token" in data:
+        set(
+            "github-copilot",
+            {
+                "type": "oauth",
+                "refresh": data["access_token"],
+                "access": "",
+                "expires": 0,
+            },
+        )
+        return "complete"
+    return data.get("error", "pending")
+
+
+def get_api_token() -> Optional[str]:
+    info = get("github-copilot")
+    if not info or info.get("type") != "oauth":
+        return None
+    if info.get("access") and info.get("expires", 0) > int(time.time() * 1000):
+        return info["access"]
+    resp = requests.get(
+        COPILOT_API_KEY_URL,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {info['refresh']}",
+            "User-Agent": "GitHubCopilotChat/0.26.7",
+            "Editor-Version": "vscode/1.99.3",
+            "Editor-Plugin-Version": "copilot-chat/0.26.7",
+        },
+    )
+    data = resp.json()
+    token = data.get("token")
+    if token:
+        set(
+            "github-copilot",
+            {
+                "type": "oauth",
+                "refresh": info["refresh"],
+                "access": token,
+                "expires": data.get("expires_at", 0) * 1000,
+            },
+        )
+    return token

--- a/scripts/auth_cli.py
+++ b/scripts/auth_cli.py
@@ -1,0 +1,74 @@
+import argparse
+import time
+
+from auth import anthropic as auth_anthropic
+from auth import github_copilot as auth_copilot
+
+
+def prompt_provider() -> str:
+    print("Select provider:")
+    print("1) Anthropic (recommended)")
+    print("2) GitHub Copilot")
+    choice = input("Enter number: ").strip()
+    return "anthropic" if choice == "1" else "github-copilot"
+
+
+def anthropic_flow():
+    result = auth_anthropic.generate_oauth_url()
+    print("Open the following URL in your browser and authorize:")
+    print(result["url"])
+    code = input("Enter the returned code: ").strip()
+    state = input("Enter the returned state: ").strip()
+    token = auth_anthropic.exchange_code(code, state, result["verifier"])
+    if token:
+        print("Anthropic authentication complete")
+    else:
+        print("Authentication failed")
+
+
+def copilot_flow():
+    step = auth_copilot.start_device_flow()
+    print(f"Visit {step['verification']} and enter code {step['user']}")
+    device = step["device"]
+    interval = step["interval"]
+    expiry = step["expiry"]
+    start = time.time()
+    while time.time() - start < expiry:
+        status = auth_copilot.poll_token(device)
+        if status == "complete":
+            break
+        elif status == "failed":
+            print("Authentication failed")
+            return
+        time.sleep(interval)
+    if status != "complete":
+        print("Timed out")
+        return
+    token = auth_copilot.get_api_token()
+    if token:
+        print("GitHub Copilot authentication complete")
+    else:
+        print("Failed to retrieve API token")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Authenticate providers")
+    parser.add_argument("login", nargs="?", help="login command")
+    parser.add_argument("provider", nargs="?", help="provider name")
+    args = parser.parse_args()
+
+    if args.login != "login":
+        parser.print_help()
+        return
+
+    provider = args.provider or prompt_provider()
+    if provider == "anthropic":
+        anthropic_flow()
+    elif provider == "github-copilot":
+        copilot_flow()
+    else:
+        print("Unknown provider")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add authentication storage under `~/.local/share/zen-mcp-server/auth.json`
- implement Anthropic OAuth token helper
- implement GitHub Copilot device/OAuth helper
- provide a small CLI to log in
- document authentication in the README

## Testing
- `ruff check --fix auth scripts`
- `black auth scripts`
- `pytest tests/test_rate_limit_patterns.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6878954a13d4832695e6c52ef5aedec8