### PR TITLE
Implement OAuth credential storage and login CLI

### DIFF
--- a/auth/__init__.py
+++ b/auth/__init__.py
@@ -1,0 +1,8 @@
+"""Authentication utilities for Zen MCP server."""
+
+from utils import auth as Storage
+
+from . import anthropic as Anthropic
+from . import copilot as Copilot
+
+__all__ = ["Anthropic", "Copilot", "Storage"]

--- a/auth/anthropic.py
+++ b/auth/anthropic.py
@@ -1,0 +1,101 @@
+"""Anthropic OAuth authentication helpers."""
+
+import time
+from typing import Optional
+
+import requests
+
+from utils.pkce import generate_pkce
+
+from . import utils
+
+CLIENT_ID = "c4aa5311-7756-40f1-aa81-b2c43ff8869e"
+AUTH_URL = "https://claude.ai/oauth/authorize"
+TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
+REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
+SCOPE = "org:create_api_key user:profile user:inference"
+
+
+def start_oauth() -> tuple[str, str]:
+    """Return authorize URL and verifier."""
+    pkce = generate_pkce()
+    url = (
+        requests.Request(
+            "GET",
+            AUTH_URL,
+            params={
+                "code": "true",
+                "client_id": CLIENT_ID,
+                "response_type": "code",
+                "redirect_uri": REDIRECT_URI,
+                "scope": SCOPE,
+                "code_challenge": pkce.challenge,
+                "code_challenge_method": "S256",
+                "state": pkce.verifier,
+            },
+        )
+        .prepare()
+        .url
+    )
+    return url, pkce.verifier
+
+
+def exchange_code(code: str, state: str, verifier: str) -> Optional[str]:
+    """Exchange authorization code for access token."""
+    response = requests.post(
+        TOKEN_URL,
+        json={
+            "code": code,
+            "state": state,
+            "grant_type": "authorization_code",
+            "client_id": CLIENT_ID,
+            "redirect_uri": REDIRECT_URI,
+            "code_verifier": verifier,
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    if not response.ok:
+        return None
+    data = response.json()
+    utils.set(
+        "anthropic",
+        {
+            "type": "oauth",
+            "refresh": data["refresh_token"],
+            "access": data["access_token"],
+            "expires": int(time.time() * 1000) + data["expires_in"] * 1000,
+        },
+    )
+    return data.get("access_token")
+
+
+def get_token() -> Optional[str]:
+    """Return a valid access token, refreshing if needed."""
+    info = utils.get("anthropic")
+    if not info or info.get("type") != "oauth":
+        return None
+    access = info.get("access")
+    if access and info.get("expires", 0) > int(time.time() * 1000):
+        return access
+    response = requests.post(
+        TOKEN_URL,
+        json={
+            "grant_type": "refresh_token",
+            "refresh_token": info.get("refresh"),
+            "client_id": CLIENT_ID,
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    if not response.ok:
+        return None
+    data = response.json()
+    utils.set(
+        "anthropic",
+        {
+            "type": "oauth",
+            "refresh": data["refresh_token"],
+            "access": data["access_token"],
+            "expires": int(time.time() * 1000) + data["expires_in"] * 1000,
+        },
+    )
+    return data.get("access_token")

--- a/auth/copilot.py
+++ b/auth/copilot.py
@@ -1,0 +1,93 @@
+"""GitHub Copilot authentication via device flow."""
+
+import time
+from typing import Optional
+
+import requests
+
+from . import utils
+
+CLIENT_ID = "d6b8c347b1a98ba3f2cd"
+DEVICE_CODE_URL = "https://github.com/login/device/code"
+ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
+COPILOT_TOKEN_URL = "https://api.githubcopilot.com/tokens"
+
+
+def start_device_flow() -> dict[str, str]:
+    """Begin the device authorization flow."""
+    resp = requests.post(
+        DEVICE_CODE_URL,
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": "Zen-MCP-Auth",
+        },
+        json={"client_id": CLIENT_ID, "scope": "read:user"},
+    )
+    data = resp.json()
+    return {
+        "device": data["device_code"],
+        "user": data["user_code"],
+        "verification": data["verification_uri"],
+        "interval": data.get("interval", 5),
+        "expiry": data["expires_in"],
+    }
+
+
+def poll_device_token(device_code: str) -> str:
+    """Poll GitHub for OAuth token."""
+    resp = requests.post(
+        ACCESS_TOKEN_URL,
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": "Zen-MCP-Auth",
+        },
+        json={
+            "client_id": CLIENT_ID,
+            "device_code": device_code,
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+        },
+    )
+    if not resp.ok:
+        return "failed"
+    data = resp.json()
+    if "access_token" in data:
+        utils.set(
+            "github-copilot",
+            {"type": "oauth", "refresh": data["access_token"], "access": "", "expires": 0},
+        )
+        return "complete"
+    return data.get("error", "pending")
+
+
+def get_copilot_token() -> Optional[str]:
+    """Return a Copilot API token, refreshing if necessary."""
+    info = utils.get("github-copilot")
+    if not info or info.get("type") != "oauth":
+        return None
+    if info.get("access") and info.get("expires", 0) > int(time.time() * 1000):
+        return info["access"]
+    resp = requests.get(
+        COPILOT_TOKEN_URL,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {info['refresh']}",
+            "User-Agent": "Zen-MCP-Auth",
+            "Editor-Version": "vscode/1.99.3",
+            "Editor-Plugin-Version": "copilot-chat/0.26.7",
+        },
+    )
+    if not resp.ok:
+        return None
+    data = resp.json()
+    utils.set(
+        "github-copilot",
+        {
+            "type": "oauth",
+            "refresh": info["refresh"],
+            "access": data["token"],
+            "expires": data["expires_at"] * 1000,
+        },
+    )
+    return data["token"]

--- a/auth_cli.py
+++ b/auth_cli.py
@@ -1,0 +1,67 @@
+import argparse
+import time
+
+from auth import Anthropic, Copilot
+
+
+def login_anthropic() -> None:
+    url, verifier = Anthropic.start_oauth()
+    print("Open the following URL in your browser and authorize:")
+    print(url)
+    code_input = input("Paste the returned 'code|state' value: ")
+    try:
+        code, state = code_input.strip().split("|")
+    except ValueError:
+        print("Invalid code format")
+        return
+    token = Anthropic.exchange_code(code, state, verifier)
+    if token:
+        print("Anthropic credentials saved")
+    else:
+        print("Authorization failed")
+
+
+def login_copilot() -> None:
+    data = Copilot.start_device_flow()
+    print("Visit", data["verification"], "and enter code", data["user"])
+    print("Waiting for authorization...")
+    expiry = time.time() + data["expiry"]
+    while time.time() < expiry:
+        status = Copilot.poll_device_token(data["device"])
+        if status == "complete":
+            print("GitHub authorization complete")
+            break
+        if status == "failed":
+            print("Authorization failed")
+            return
+        time.sleep(data["interval"])
+    else:
+        print("Authorization timed out")
+
+
+def login() -> None:
+    choices = {"1": ("Anthropic", login_anthropic), "2": ("GitHub Copilot", login_copilot)}
+    print("Select provider:")
+    for key, (name, _) in choices.items():
+        print(f"{key}. {name}")
+    selection = input("Provider: ").strip()
+    if selection in choices:
+        choices[selection][1]()
+    else:
+        print("Invalid selection")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage authentication")
+    sub = parser.add_subparsers(dest="command")
+    sub.add_parser("login")
+    args = parser.parse_args()
+
+    if args.command == "login":
+        login()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["tools*", "providers*", "systemprompts*", "utils*"]
+include = ["tools*", "providers*", "systemprompts*", "utils*", "auth*"]
 
 [tool.setuptools]
 py-modules = ["server", "config"]

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -1,0 +1,42 @@
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+APP_NAME = "zen-mcp-server"
+
+
+def _filepath() -> Path:
+    data_dir = Path.home() / ".local" / "share" / APP_NAME
+    data_dir.mkdir(parents=True, exist_ok=True)
+    return data_dir / "auth.json"
+
+
+def load_all() -> dict[str, Any]:
+    """Load all stored auth info."""
+    file = _filepath()
+    if not file.exists():
+        return {}
+    try:
+        with open(file, encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def get(key: str) -> Optional[dict[str, Any]]:
+    """Get auth info for provider."""
+    return load_all().get(key)
+
+
+def set(key: str, info: dict[str, Any]) -> None:
+    """Store auth info for provider and restrict file permissions."""
+    data = load_all()
+    data[key] = info
+    file = _filepath()
+    with open(file, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    try:
+        os.chmod(file, 0o600)
+    except OSError:
+        pass

--- a/utils/pkce.py
+++ b/utils/pkce.py
@@ -1,0 +1,19 @@
+import base64
+import hashlib
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class PKCE:
+    verifier: str
+    challenge: str
+
+
+def generate_pkce() -> PKCE:
+    """Generate PKCE verifier and challenge."""
+    verifier_bytes = os.urandom(32)
+    verifier = base64.urlsafe_b64encode(verifier_bytes).rstrip(b"=").decode()
+    challenge_digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(challenge_digest).rstrip(b"=").decode()
+    return PKCE(verifier=verifier, challenge=challenge)


### PR DESCRIPTION
## Summary
- add `auth` package with Anthropic and GitHub Copilot OAuth helpers
- provide PKCE generation and credential storage utilities
- expose a simple `auth_cli.py login` command to guide authentication
- include new modules in packaging configuration
- format code with ruff/black and pass unit tests

## Testing
- `ruff check --fix`
- `black . --exclude="test_simulation_files/"`
- `isort . --skip-glob=".zen_venv/*" --skip-glob="test_simulation_files/*"`
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878954a13d4832695e6c52ef5aedec8