### PR TITLE
Add OAuth auth storage and helpers

### DIFF
--- a/auth/__init__.py
+++ b/auth/__init__.py
@@ -1,0 +1,63 @@
+"""Credential storage utilities for Zen MCP Server.
+
+This module replicates the simple credential storage
+mechanism used by OpenCode. Credentials are persisted in a
+JSON file located in ``~/.local/share/zen-mcp-server/auth.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+DATA_DIR = Path(os.getenv("XDG_DATA_HOME", Path.home() / ".local" / "share")) / "zen-mcp-server"
+AUTH_FILE = DATA_DIR / "auth.json"
+
+
+@dataclass
+class Info:
+    """Credential information structure."""
+
+    type: str
+    refresh: str
+    access: str
+    expires: int
+
+
+def _load() -> dict[str, Any]:
+    if AUTH_FILE.exists():
+        try:
+            with AUTH_FILE.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return {}
+    return {}
+
+
+def all() -> dict[str, Any]:
+    """Return all stored credentials."""
+
+    return _load()
+
+
+def get(key: str) -> Info | None:
+    data = _load()
+    value = data.get(key)
+    if value is None:
+        return None
+    try:
+        return Info(**value)
+    except Exception:
+        return None
+
+
+def set(key: str, info: Info) -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    data = _load()
+    data[key] = asdict(info)
+    with AUTH_FILE.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    os.chmod(AUTH_FILE, 0o600)

--- a/auth/anthropic.py
+++ b/auth/anthropic.py
@@ -1,0 +1,106 @@
+"""Anthropic authentication helpers.
+
+These functions implement the OAuth flow used by OpenCode for
+obtaining and refreshing Anthropic API tokens.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import secrets
+import time
+
+import httpx
+
+from . import Info, get, set
+
+CLIENT_ID = os.getenv("ANTHROPIC_CLIENT_ID", "opencode")
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode().rstrip("=")
+
+
+def generate_pkce() -> tuple[str, str]:
+    """Return (verifier, challenge) for PKCE OAuth."""
+
+    verifier_bytes = secrets.token_bytes(32)
+    verifier = _b64url(verifier_bytes)
+    challenge = _b64url(hashlib.sha256(verifier.encode()).digest())
+    return verifier, challenge
+
+
+def oauth_url() -> tuple[str, str]:
+    """Return OAuth URL and verifier for login."""
+
+    verifier, challenge = generate_pkce()
+    url = httpx.URL("https://claude.ai/oauth/authorize")
+    url = url.copy_add_param("code", "true")
+    url = url.copy_add_param("client_id", CLIENT_ID)
+    url = url.copy_add_param("response_type", "code")
+    url = url.copy_add_param("redirect_uri", "https://console.anthropic.com/oauth/code/callback")
+    url = url.copy_add_param("scope", "org:create_api_key user:profile user:inference")
+    url = url.copy_add_param("code_challenge", challenge)
+    url = url.copy_add_param("code_challenge_method", "S256")
+    url = url.copy_add_param("state", verifier)
+    return str(url), verifier
+
+
+def exchange_code(code: str, state: str, verifier: str) -> str | None:
+    """Exchange authorization code for tokens and store them."""
+
+    response = httpx.post(
+        "https://console.anthropic.com/v1/oauth/token",
+        json={
+            "code": code,
+            "state": state,
+            "grant_type": "authorization_code",
+            "client_id": CLIENT_ID,
+            "redirect_uri": "https://console.anthropic.com/oauth/code/callback",
+            "code_verifier": verifier,
+        },
+        headers={"Content-Type": "application/json"},
+        timeout=30.0,
+    )
+    response.raise_for_status()
+    data = response.json()
+    info = Info(
+        type="oauth",
+        refresh=data["refresh_token"],
+        access=data["access_token"],
+        expires=int(time.time() * 1000) + int(data["expires_in"]) * 1000,
+    )
+    set("anthropic", info)
+    return data["access_token"]
+
+
+def get_access_token() -> str | None:
+    """Return a valid Anthropic access token, refreshing if needed."""
+
+    info = get("anthropic")
+    if not info or info.type != "oauth":
+        return None
+    if info.access and info.expires > int(time.time() * 1000):
+        return info.access
+    response = httpx.post(
+        "https://console.anthropic.com/v1/oauth/token",
+        json={
+            "grant_type": "refresh_token",
+            "refresh_token": info.refresh,
+            "client_id": CLIENT_ID,
+        },
+        headers={"Content-Type": "application/json"},
+        timeout=30.0,
+    )
+    response.raise_for_status()
+    data = response.json()
+    new_info = Info(
+        type="oauth",
+        refresh=data["refresh_token"],
+        access=data["access_token"],
+        expires=int(time.time() * 1000) + int(data["expires_in"]) * 1000,
+    )
+    set("anthropic", new_info)
+    return new_info.access

--- a/auth/copilot_plugin.py
+++ b/auth/copilot_plugin.py
@@ -1,0 +1,44 @@
+"""Optional dynamic loader for GitHub Copilot auth logic.
+
+This mirrors the lazy loading mechanism from OpenCode. The helper downloads
+an auth script from GitHub and imports it at runtime if available.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from types import ModuleType
+
+import httpx
+
+STATE_DIR = Path(os.getenv("XDG_STATE_HOME", Path.home() / ".local" / "state")) / "zen-mcp-server"
+PLUGIN_PATH = STATE_DIR / "plugin" / "copilot.py"
+
+
+def load_remote() -> ModuleType | None:
+    """Download and import the remote Copilot auth module."""
+
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    PLUGIN_PATH.parent.mkdir(parents=True, exist_ok=True)
+    url = "https://raw.githubusercontent.com/sst/opencode-github-copilot/refs/heads/main/auth.py"
+    try:
+        resp = httpx.get(url, timeout=10.0)
+        if resp.status_code == 200:
+            PLUGIN_PATH.write_text(resp.text)
+    except Exception:
+        return None
+
+    if not PLUGIN_PATH.exists():
+        return None
+
+    spec = importlib.util.spec_from_file_location("copilot_plugin", str(PLUGIN_PATH))
+    if not spec or not spec.loader:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)  # type: ignore[arg-type]
+    except Exception:
+        return None
+    return module

--- a/auth/github_copilot.py
+++ b/auth/github_copilot.py
@@ -1,0 +1,91 @@
+"""GitHub Copilot authentication helpers.
+
+Implements the device code OAuth flow and token retrieval
+for the Copilot API used by OpenCode.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import httpx
+
+from . import Info, get, set
+
+CLIENT_ID = os.getenv("GITHUB_COPILOT_CLIENT_ID", "d8e2041f4ccf400ab4d8")
+DEVICE_CODE_URL = "https://github.com/login/device/code"
+ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
+COPILOT_API_KEY_URL = "https://api.github.com/copilot_internal/v2/token"
+USER_AGENT = "GitHubCopilotChat/0.26.7"
+
+
+def start_device_flow() -> dict:
+    """Initiate the device authorization flow."""
+
+    resp = httpx.post(
+        DEVICE_CODE_URL,
+        json={"client_id": CLIENT_ID, "scope": "read:user"},
+        headers={"Accept": "application/json", "Content-Type": "application/json", "User-Agent": USER_AGENT},
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def poll_oauth_token(device_code: str, interval: int) -> str | None:
+    """Poll GitHub until an OAuth token is returned."""
+
+    while True:
+        time.sleep(interval)
+        resp = httpx.post(
+            ACCESS_TOKEN_URL,
+            json={
+                "client_id": CLIENT_ID,
+                "device_code": device_code,
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            },
+            headers={"Accept": "application/json", "Content-Type": "application/json", "User-Agent": USER_AGENT},
+            timeout=30.0,
+        )
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+        if data.get("access_token"):
+            info = Info(type="oauth", refresh=data["access_token"], access="", expires=0)
+            set("github-copilot", info)
+            return data["access_token"]
+        if data.get("error") not in ("authorization_pending", "slow_down"):
+            return None
+
+
+def get_copilot_token() -> str | None:
+    """Return a valid Copilot API token, retrieving one if necessary."""
+
+    info = get("github-copilot")
+    if not info or info.type != "oauth":
+        return None
+    if info.access and info.expires > int(time.time() * 1000):
+        return info.access
+
+    resp = httpx.get(
+        COPILOT_API_KEY_URL,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {info.refresh}",
+            "User-Agent": USER_AGENT,
+            "Editor-Version": "vscode/1.99.3",
+            "Editor-Plugin-Version": "copilot-chat/0.26.7",
+        },
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    new_info = Info(
+        type="oauth",
+        refresh=info.refresh,
+        access=data["token"],
+        expires=int(data["expires_at"]) * 1000,
+    )
+    set("github-copilot", new_info)
+    return new_info.access

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["tools*", "providers*", "systemprompts*", "utils*"]
+include = ["tools*", "providers*", "systemprompts*", "utils*", "auth*"]
 
 [tool.setuptools]
 py-modules = ["server", "config"]

--- a/scripts/auth_cli.py
+++ b/scripts/auth_cli.py
@@ -1,0 +1,60 @@
+"""Simple CLI for managing authentication credentials."""
+
+from __future__ import annotations
+
+from auth.anthropic import exchange_code, oauth_url
+from auth.github_copilot import get_copilot_token, poll_oauth_token, start_device_flow
+
+
+def select_provider() -> str:
+    print("\nAdd credential\n")
+    print("Select provider")
+    print("1) Anthropic (recommended)")
+    print("2) GitHub Copilot")
+    choice = input("Enter number: ").strip()
+    if choice == "1":
+        return "anthropic"
+    if choice == "2":
+        return "github-copilot"
+    raise SystemExit("Unknown choice")
+
+
+def anthropic_flow() -> None:
+    url, verifier = oauth_url()
+    print("\nOpen the following URL in your browser and complete login:\n")
+    print(url)
+    print("\nAfter granting access, you will be redirected to a URL containing 'code' and 'state' parameters.")
+    code = input("Enter the value of 'code': ").strip()
+    state = input("Enter the value of 'state': ").strip()
+    token = exchange_code(code, state, verifier)
+    if token:
+        print("Anthropic credentials saved.")
+    else:
+        print("Authentication failed.")
+
+
+def copilot_flow() -> None:
+    data = start_device_flow()
+    print("\nVisit", data["verification_uri"], "and enter code", data["user_code"])
+    print("Waiting for authorization...")
+    token = poll_oauth_token(data["device_code"], data.get("interval", 5))
+    if not token:
+        print("Authorization failed.")
+        return
+    api_token = get_copilot_token()
+    if api_token:
+        print("GitHub Copilot credentials saved.")
+    else:
+        print("Failed to obtain Copilot API token.")
+
+
+def main() -> None:
+    provider = select_provider()
+    if provider == "anthropic":
+        anthropic_flow()
+    elif provider == "github-copilot":
+        copilot_flow()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- manage tokens in `~/.local/share/zen-mcp-server/auth.json`
- implement Anthropic OAuth PKCE flow and token refresh
- add GitHub Copilot device OAuth flow
- optional remote plugin loader
- simple CLI for interactive login
- include new `auth` package in `pyproject.toml`

## Testing
- `ruff check auth scripts/auth_cli.py`
- `black auth scripts/auth_cli.py`
- `isort auth scripts/auth_cli.py`
- `python -m pytest tests/ -v -x -m "not integration"`

------
https://chatgpt.com/codex/tasks/task_e_6878954a13d4832695e6c52ef5aedec8